### PR TITLE
Fixed missing separator error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
 all:
-  echo "Hello $(USER)!"
+	echo "Hello $(USER)!"


### PR DESCRIPTION
github editor used spaces in place of tab, which make does not recognize. This corrects that
